### PR TITLE
Fix Description Loadout Not Appearing on Description.ext

### DIFF
--- a/Arma3PhantomMissionEditorLoader/Form3_Description.cs
+++ b/Arma3PhantomMissionEditorLoader/Form3_Description.cs
@@ -50,6 +50,12 @@ namespace Arma3PhantomMissionEditorLoader
 			this.minPlayers = minPlayers;
 			this.maxPlayers = maxPlayers;
 
+			initializeInformation();
+		}
+
+		private void description_button_Click(object sender, EventArgs e)
+		{
+			// Set parameters information once button is click to get checkbox latest state
 			this.parameters = new Dictionary<String, Object>
 			{
 				{"description_params", description_params_checkbox.Checked},
@@ -67,11 +73,6 @@ namespace Arma3PhantomMissionEditorLoader
 				}
 			};
 
-			initializeInformation();
-		}
-
-		private void description_button_Click(object sender, EventArgs e)
-		{
 			// Create scripts folder 
 			System.IO.Directory.CreateDirectory(System.IO.Path.Combine(this.missionDirectory, FOLDER_SCRIPTS));
 


### PR DESCRIPTION
GitHub Issue: https://github.com/bennpham/Arma3PhantomMissionEditorLoader/issues/4

This basically moves setting the parameters to when the complete button is click instead of during init which will get the state of only the checkbox default state, not after it was selected or deselected. This prevented importing the `briefing_loadout.hpp` from being imported to `description.ext`.