### PR TITLE
Add Support for FHQ Eden and ACE settings in init.sqf

### DIFF
--- a/Arma3PhantomMissionEditorLoader/Form2_MissionSqmSettings.cs
+++ b/Arma3PhantomMissionEditorLoader/Form2_MissionSqmSettings.cs
@@ -208,7 +208,7 @@ namespace Arma3PhantomMissionEditorLoader
 		private String formatDateForInfoText(String date)
 		{
 			String[] dateArray = date.Split(',');
-			String formattedDate = "{dateArray[1]}, {dateArray[2]}";
+			String formattedDate = dateArray[1].Trim() + "," + dateArray[2];
 			
 			return formattedDate;
 		}

--- a/Arma3PhantomMissionEditorLoader/Form2_MissionSqmSettings.cs
+++ b/Arma3PhantomMissionEditorLoader/Form2_MissionSqmSettings.cs
@@ -192,13 +192,25 @@ namespace Arma3PhantomMissionEditorLoader
 			// GoTo Generate infotext Form
 			//		Pick Name of Mission to Display (already have date and Author)
 			this.Hide();
-			Form3_Description form3_description = new Form3_Description(this.missionDirectory, date.Text,
-				formatTimeString(this.hour.Value.ToString()), formatTimeString(this.minute.Value.ToString()), 
+			Form3_Description form3_description = new Form3_Description(this.missionDirectory, 
+				formatDateForInfoText(date.Text),
+				formatTimeString(this.hour.Value.ToString()), 
+				formatTimeString(this.minute.Value.ToString()), 
 				textbox_author.Text,
 				"OnLoadName = \"" + textBox_onLoadName.Text.Replace("\"", "\"\"").Replace(Environment.NewLine, " ") + "\";",
 				"OnLoadMission =\"" + textBox_onLoadMission.Text.Replace("\"", "\"\"").Replace(Environment.NewLine, " ") + "\";",
-				min_players.Value.ToString(), max_players.Value.ToString());
+				min_players.Value.ToString(), 
+				max_players.Value.ToString());
 			form3_description.ShowDialog();
+		}
+
+		// Helper function to strip out day for Date to avoid infotext from going off the screen
+		private String formatDateForInfoText(String date)
+		{
+			String[] dateArray = date.Split(',');
+			String formattedDate = "{dateArray[1]}, {dateArray[2]}";
+			
+			return formattedDate;
 		}
 
 		/*===========================================================

--- a/Arma3PhantomMissionEditorLoader/Form3_Description.Designer.cs
+++ b/Arma3PhantomMissionEditorLoader/Form3_Description.Designer.cs
@@ -29,7 +29,7 @@
 		private void InitializeComponent()
 		{
 			this.title_description = new System.Windows.Forms.Label();
-			this.description_params_checkbox = new System.Windows.Forms.CheckBox();
+			this.description_params_scale_players_checkbox = new System.Windows.Forms.CheckBox();
 			this.description_loadout_checkbox = new System.Windows.Forms.CheckBox();
 			this.description_button = new System.Windows.Forms.Button();
 			this.title_infotext = new System.Windows.Forms.Label();
@@ -38,6 +38,7 @@
 			this.label_datetime = new System.Windows.Forms.Label();
 			this.init_zeus_checkbox = new System.Windows.Forms.CheckBox();
 			this.init_zeus_label = new System.Windows.Forms.Label();
+			this.description_params_difficulty_checkbox = new System.Windows.Forms.CheckBox();
 			this.SuspendLayout();
 			// 
 			// title_description
@@ -51,24 +52,24 @@
 			this.title_description.Text = "Description";
 			this.title_description.TextAlign = System.Drawing.ContentAlignment.TopCenter;
 			// 
-			// description_params_checkbox
+			// description_params_scale_players_checkbox
 			// 
-			this.description_params_checkbox.AutoSize = true;
-			this.description_params_checkbox.Checked = true;
-			this.description_params_checkbox.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.description_params_checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.description_params_checkbox.Location = new System.Drawing.Point(17, 41);
-			this.description_params_checkbox.Name = "description_params_checkbox";
-			this.description_params_checkbox.Size = new System.Drawing.Size(314, 24);
-			this.description_params_checkbox.TabIndex = 11;
-			this.description_params_checkbox.Text = "Description Params (Player Count Scale)";
-			this.description_params_checkbox.UseVisualStyleBackColor = true;
+			this.description_params_scale_players_checkbox.AutoSize = true;
+			this.description_params_scale_players_checkbox.Checked = true;
+			this.description_params_scale_players_checkbox.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.description_params_scale_players_checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.description_params_scale_players_checkbox.Location = new System.Drawing.Point(17, 41);
+			this.description_params_scale_players_checkbox.Name = "description_params_scale_players_checkbox";
+			this.description_params_scale_players_checkbox.Size = new System.Drawing.Size(314, 24);
+			this.description_params_scale_players_checkbox.TabIndex = 11;
+			this.description_params_scale_players_checkbox.Text = "Description Params (Player Count Scale)";
+			this.description_params_scale_players_checkbox.UseVisualStyleBackColor = true;
 			// 
 			// description_loadout_checkbox
 			// 
 			this.description_loadout_checkbox.AutoSize = true;
 			this.description_loadout_checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.description_loadout_checkbox.Location = new System.Drawing.Point(17, 71);
+			this.description_loadout_checkbox.Location = new System.Drawing.Point(17, 101);
 			this.description_loadout_checkbox.Name = "description_loadout_checkbox";
 			this.description_loadout_checkbox.Size = new System.Drawing.Size(306, 24);
 			this.description_loadout_checkbox.TabIndex = 12;
@@ -78,7 +79,7 @@
 			// description_button
 			// 
 			this.description_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 20.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.description_button.Location = new System.Drawing.Point(176, 376);
+			this.description_button.Location = new System.Drawing.Point(176, 407);
 			this.description_button.Name = "description_button";
 			this.description_button.Size = new System.Drawing.Size(147, 38);
 			this.description_button.TabIndex = 13;
@@ -90,7 +91,7 @@
 			// 
 			this.title_infotext.AutoSize = true;
 			this.title_infotext.Font = new System.Drawing.Font("Microsoft Sans Serif", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.title_infotext.Location = new System.Drawing.Point(12, 172);
+			this.title_infotext.Location = new System.Drawing.Point(12, 203);
 			this.title_infotext.Name = "title_infotext";
 			this.title_infotext.Size = new System.Drawing.Size(174, 29);
 			this.title_infotext.TabIndex = 14;
@@ -99,7 +100,7 @@
 			// 
 			// infotext_title
 			// 
-			this.infotext_title.Location = new System.Drawing.Point(12, 248);
+			this.infotext_title.Location = new System.Drawing.Point(12, 279);
 			this.infotext_title.Multiline = true;
 			this.infotext_title.Name = "infotext_title";
 			this.infotext_title.Size = new System.Drawing.Size(440, 75);
@@ -109,7 +110,7 @@
 			// 
 			this.label_created_by.AutoSize = true;
 			this.label_created_by.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_created_by.Location = new System.Drawing.Point(13, 335);
+			this.label_created_by.Location = new System.Drawing.Point(13, 366);
 			this.label_created_by.Name = "label_created_by";
 			this.label_created_by.Size = new System.Drawing.Size(174, 20);
 			this.label_created_by.TabIndex = 22;
@@ -119,7 +120,7 @@
 			// 
 			this.label_datetime.AutoSize = true;
 			this.label_datetime.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_datetime.Location = new System.Drawing.Point(12, 215);
+			this.label_datetime.Location = new System.Drawing.Point(12, 246);
 			this.label_datetime.Name = "label_datetime";
 			this.label_datetime.Size = new System.Drawing.Size(199, 20);
 			this.label_datetime.TabIndex = 23;
@@ -131,7 +132,7 @@
 			this.init_zeus_checkbox.Checked = true;
 			this.init_zeus_checkbox.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.init_zeus_checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.init_zeus_checkbox.Location = new System.Drawing.Point(17, 112);
+			this.init_zeus_checkbox.Location = new System.Drawing.Point(17, 143);
 			this.init_zeus_checkbox.Name = "init_zeus_checkbox";
 			this.init_zeus_checkbox.Size = new System.Drawing.Size(306, 24);
 			this.init_zeus_checkbox.TabIndex = 24;
@@ -142,17 +143,31 @@
 			// 
 			this.init_zeus_label.AutoSize = true;
 			this.init_zeus_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.init_zeus_label.Location = new System.Drawing.Point(12, 139);
+			this.init_zeus_label.Location = new System.Drawing.Point(12, 170);
 			this.init_zeus_label.Name = "init_zeus_label";
 			this.init_zeus_label.Size = new System.Drawing.Size(427, 17);
 			this.init_zeus_label.TabIndex = 25;
 			this.init_zeus_label.Text = "Need to name the zeus slots zeus_mod1, zeus_mod2, zeus_mod3";
 			// 
+			// description_params_difficulty_checkbox
+			// 
+			this.description_params_difficulty_checkbox.AutoSize = true;
+			this.description_params_difficulty_checkbox.Checked = true;
+			this.description_params_difficulty_checkbox.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.description_params_difficulty_checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.description_params_difficulty_checkbox.Location = new System.Drawing.Point(17, 71);
+			this.description_params_difficulty_checkbox.Name = "description_params_difficulty_checkbox";
+			this.description_params_difficulty_checkbox.Size = new System.Drawing.Size(278, 24);
+			this.description_params_difficulty_checkbox.TabIndex = 26;
+			this.description_params_difficulty_checkbox.Text = "Description Params (FHQ Difficulty)";
+			this.description_params_difficulty_checkbox.UseVisualStyleBackColor = true;
+			// 
 			// Form3_Description
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(464, 421);
+			this.ClientSize = new System.Drawing.Size(464, 457);
+			this.Controls.Add(this.description_params_difficulty_checkbox);
 			this.Controls.Add(this.init_zeus_label);
 			this.Controls.Add(this.init_zeus_checkbox);
 			this.Controls.Add(this.label_datetime);
@@ -161,7 +176,7 @@
 			this.Controls.Add(this.title_infotext);
 			this.Controls.Add(this.description_button);
 			this.Controls.Add(this.description_loadout_checkbox);
-			this.Controls.Add(this.description_params_checkbox);
+			this.Controls.Add(this.description_params_scale_players_checkbox);
 			this.Controls.Add(this.title_description);
 			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
 			this.MaximizeBox = false;
@@ -175,7 +190,7 @@
 		#endregion
 
 		private System.Windows.Forms.Label title_description;
-		private System.Windows.Forms.CheckBox description_params_checkbox;
+		private System.Windows.Forms.CheckBox description_params_scale_players_checkbox;
 		private System.Windows.Forms.CheckBox description_loadout_checkbox;
 		private System.Windows.Forms.Button description_button;
 		private System.Windows.Forms.Label title_infotext;
@@ -184,5 +199,6 @@
 		private System.Windows.Forms.Label label_datetime;
 		private System.Windows.Forms.CheckBox init_zeus_checkbox;
 		private System.Windows.Forms.Label init_zeus_label;
+		private System.Windows.Forms.CheckBox description_params_difficulty_checkbox;
 	}
 }

--- a/Arma3PhantomMissionEditorLoader/Form3_Description.Designer.cs
+++ b/Arma3PhantomMissionEditorLoader/Form3_Description.Designer.cs
@@ -39,6 +39,9 @@
 			this.init_zeus_checkbox = new System.Windows.Forms.CheckBox();
 			this.init_zeus_label = new System.Windows.Forms.Label();
 			this.description_params_difficulty_checkbox = new System.Windows.Forms.CheckBox();
+			this.init_ace_label = new System.Windows.Forms.Label();
+			this.init_ace_checkbox = new System.Windows.Forms.CheckBox();
+			this.init_ace_label2 = new System.Windows.Forms.Label();
 			this.SuspendLayout();
 			// 
 			// title_description
@@ -79,7 +82,7 @@
 			// description_button
 			// 
 			this.description_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 20.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.description_button.Location = new System.Drawing.Point(176, 407);
+			this.description_button.Location = new System.Drawing.Point(176, 467);
 			this.description_button.Name = "description_button";
 			this.description_button.Size = new System.Drawing.Size(147, 38);
 			this.description_button.TabIndex = 13;
@@ -91,7 +94,7 @@
 			// 
 			this.title_infotext.AutoSize = true;
 			this.title_infotext.Font = new System.Drawing.Font("Microsoft Sans Serif", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.title_infotext.Location = new System.Drawing.Point(12, 203);
+			this.title_infotext.Location = new System.Drawing.Point(12, 263);
 			this.title_infotext.Name = "title_infotext";
 			this.title_infotext.Size = new System.Drawing.Size(174, 29);
 			this.title_infotext.TabIndex = 14;
@@ -100,7 +103,7 @@
 			// 
 			// infotext_title
 			// 
-			this.infotext_title.Location = new System.Drawing.Point(12, 279);
+			this.infotext_title.Location = new System.Drawing.Point(12, 339);
 			this.infotext_title.Multiline = true;
 			this.infotext_title.Name = "infotext_title";
 			this.infotext_title.Size = new System.Drawing.Size(440, 75);
@@ -110,7 +113,7 @@
 			// 
 			this.label_created_by.AutoSize = true;
 			this.label_created_by.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_created_by.Location = new System.Drawing.Point(13, 366);
+			this.label_created_by.Location = new System.Drawing.Point(13, 426);
 			this.label_created_by.Name = "label_created_by";
 			this.label_created_by.Size = new System.Drawing.Size(174, 20);
 			this.label_created_by.TabIndex = 22;
@@ -120,7 +123,7 @@
 			// 
 			this.label_datetime.AutoSize = true;
 			this.label_datetime.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_datetime.Location = new System.Drawing.Point(12, 246);
+			this.label_datetime.Location = new System.Drawing.Point(12, 306);
 			this.label_datetime.Name = "label_datetime";
 			this.label_datetime.Size = new System.Drawing.Size(199, 20);
 			this.label_datetime.TabIndex = 23;
@@ -132,7 +135,7 @@
 			this.init_zeus_checkbox.Checked = true;
 			this.init_zeus_checkbox.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.init_zeus_checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.init_zeus_checkbox.Location = new System.Drawing.Point(17, 143);
+			this.init_zeus_checkbox.Location = new System.Drawing.Point(17, 208);
 			this.init_zeus_checkbox.Name = "init_zeus_checkbox";
 			this.init_zeus_checkbox.Size = new System.Drawing.Size(306, 24);
 			this.init_zeus_checkbox.TabIndex = 24;
@@ -143,7 +146,7 @@
 			// 
 			this.init_zeus_label.AutoSize = true;
 			this.init_zeus_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.init_zeus_label.Location = new System.Drawing.Point(12, 170);
+			this.init_zeus_label.Location = new System.Drawing.Point(14, 235);
 			this.init_zeus_label.Name = "init_zeus_label";
 			this.init_zeus_label.Size = new System.Drawing.Size(427, 17);
 			this.init_zeus_label.TabIndex = 25;
@@ -162,11 +165,45 @@
 			this.description_params_difficulty_checkbox.Text = "Description Params (FHQ Difficulty)";
 			this.description_params_difficulty_checkbox.UseVisualStyleBackColor = true;
 			// 
+			// init_ace_label
+			// 
+			this.init_ace_label.AutoSize = true;
+			this.init_ace_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.init_ace_label.Location = new System.Drawing.Point(14, 169);
+			this.init_ace_label.Name = "init_ace_label";
+			this.init_ace_label.Size = new System.Drawing.Size(416, 17);
+			this.init_ace_label.TabIndex = 28;
+			this.init_ace_label.Text = "Use vestContainer _unit or uniformContainer _unit or _ammobox ";
+			// 
+			// init_ace_checkbox
+			// 
+			this.init_ace_checkbox.AutoSize = true;
+			this.init_ace_checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.init_ace_checkbox.Location = new System.Drawing.Point(17, 142);
+			this.init_ace_checkbox.Name = "init_ace_checkbox";
+			this.init_ace_checkbox.Size = new System.Drawing.Size(441, 24);
+			this.init_ace_checkbox.TabIndex = 27;
+			this.init_ace_checkbox.Text = "Init ACE extra (for adding extra ace items to players or box)";
+			this.init_ace_checkbox.UseVisualStyleBackColor = true;
+			// 
+			// init_ace_label2
+			// 
+			this.init_ace_label2.AutoSize = true;
+			this.init_ace_label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.init_ace_label2.Location = new System.Drawing.Point(14, 186);
+			this.init_ace_label2.Name = "init_ace_label2";
+			this.init_ace_label2.Size = new System.Drawing.Size(347, 17);
+			this.init_ace_label2.TabIndex = 29;
+			this.init_ace_label2.Text = "addItemCargoGlobal [\"ACE_bloodIV\", 2]; or something";
+			// 
 			// Form3_Description
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(464, 457);
+			this.ClientSize = new System.Drawing.Size(464, 517);
+			this.Controls.Add(this.init_ace_label2);
+			this.Controls.Add(this.init_ace_label);
+			this.Controls.Add(this.init_ace_checkbox);
 			this.Controls.Add(this.description_params_difficulty_checkbox);
 			this.Controls.Add(this.init_zeus_label);
 			this.Controls.Add(this.init_zeus_checkbox);
@@ -200,5 +237,8 @@
 		private System.Windows.Forms.CheckBox init_zeus_checkbox;
 		private System.Windows.Forms.Label init_zeus_label;
 		private System.Windows.Forms.CheckBox description_params_difficulty_checkbox;
+		private System.Windows.Forms.Label init_ace_label;
+		private System.Windows.Forms.CheckBox init_ace_checkbox;
+		private System.Windows.Forms.Label init_ace_label2;
 	}
 }

--- a/Arma3PhantomMissionEditorLoader/Form3_Description.Designer.cs
+++ b/Arma3PhantomMissionEditorLoader/Form3_Description.Designer.cs
@@ -41,7 +41,6 @@
 			this.description_params_difficulty_checkbox = new System.Windows.Forms.CheckBox();
 			this.init_ace_label = new System.Windows.Forms.Label();
 			this.init_ace_checkbox = new System.Windows.Forms.CheckBox();
-			this.init_ace_label2 = new System.Windows.Forms.Label();
 			this.SuspendLayout();
 			// 
 			// title_description
@@ -82,7 +81,7 @@
 			// description_button
 			// 
 			this.description_button.Font = new System.Drawing.Font("Microsoft Sans Serif", 20.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.description_button.Location = new System.Drawing.Point(176, 467);
+			this.description_button.Location = new System.Drawing.Point(176, 460);
 			this.description_button.Name = "description_button";
 			this.description_button.Size = new System.Drawing.Size(147, 38);
 			this.description_button.TabIndex = 13;
@@ -94,7 +93,7 @@
 			// 
 			this.title_infotext.AutoSize = true;
 			this.title_infotext.Font = new System.Drawing.Font("Microsoft Sans Serif", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.title_infotext.Location = new System.Drawing.Point(12, 263);
+			this.title_infotext.Location = new System.Drawing.Point(12, 256);
 			this.title_infotext.Name = "title_infotext";
 			this.title_infotext.Size = new System.Drawing.Size(174, 29);
 			this.title_infotext.TabIndex = 14;
@@ -103,7 +102,7 @@
 			// 
 			// infotext_title
 			// 
-			this.infotext_title.Location = new System.Drawing.Point(12, 339);
+			this.infotext_title.Location = new System.Drawing.Point(12, 332);
 			this.infotext_title.Multiline = true;
 			this.infotext_title.Name = "infotext_title";
 			this.infotext_title.Size = new System.Drawing.Size(440, 75);
@@ -113,7 +112,7 @@
 			// 
 			this.label_created_by.AutoSize = true;
 			this.label_created_by.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_created_by.Location = new System.Drawing.Point(13, 426);
+			this.label_created_by.Location = new System.Drawing.Point(13, 419);
 			this.label_created_by.Name = "label_created_by";
 			this.label_created_by.Size = new System.Drawing.Size(174, 20);
 			this.label_created_by.TabIndex = 22;
@@ -123,7 +122,7 @@
 			// 
 			this.label_datetime.AutoSize = true;
 			this.label_datetime.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_datetime.Location = new System.Drawing.Point(12, 306);
+			this.label_datetime.Location = new System.Drawing.Point(12, 299);
 			this.label_datetime.Name = "label_datetime";
 			this.label_datetime.Size = new System.Drawing.Size(199, 20);
 			this.label_datetime.TabIndex = 23;
@@ -135,7 +134,7 @@
 			this.init_zeus_checkbox.Checked = true;
 			this.init_zeus_checkbox.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.init_zeus_checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.init_zeus_checkbox.Location = new System.Drawing.Point(17, 208);
+			this.init_zeus_checkbox.Location = new System.Drawing.Point(17, 201);
 			this.init_zeus_checkbox.Name = "init_zeus_checkbox";
 			this.init_zeus_checkbox.Size = new System.Drawing.Size(306, 24);
 			this.init_zeus_checkbox.TabIndex = 24;
@@ -146,7 +145,7 @@
 			// 
 			this.init_zeus_label.AutoSize = true;
 			this.init_zeus_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.init_zeus_label.Location = new System.Drawing.Point(14, 235);
+			this.init_zeus_label.Location = new System.Drawing.Point(14, 228);
 			this.init_zeus_label.Name = "init_zeus_label";
 			this.init_zeus_label.Size = new System.Drawing.Size(427, 17);
 			this.init_zeus_label.TabIndex = 25;
@@ -169,39 +168,28 @@
 			// 
 			this.init_ace_label.AutoSize = true;
 			this.init_ace_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.init_ace_label.Location = new System.Drawing.Point(14, 169);
+			this.init_ace_label.Location = new System.Drawing.Point(14, 178);
 			this.init_ace_label.Name = "init_ace_label";
-			this.init_ace_label.Size = new System.Drawing.Size(416, 17);
+			this.init_ace_label.Size = new System.Drawing.Size(327, 17);
 			this.init_ace_label.TabIndex = 28;
-			this.init_ace_label.Text = "Use vestContainer _unit or uniformContainer _unit or _ammobox ";
+			this.init_ace_label.Text = "Add extra ace equipment to players or ammoboxes";
 			// 
 			// init_ace_checkbox
 			// 
 			this.init_ace_checkbox.AutoSize = true;
 			this.init_ace_checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.init_ace_checkbox.Location = new System.Drawing.Point(17, 142);
+			this.init_ace_checkbox.Location = new System.Drawing.Point(17, 151);
 			this.init_ace_checkbox.Name = "init_ace_checkbox";
-			this.init_ace_checkbox.Size = new System.Drawing.Size(441, 24);
+			this.init_ace_checkbox.Size = new System.Drawing.Size(322, 24);
 			this.init_ace_checkbox.TabIndex = 27;
-			this.init_ace_checkbox.Text = "Init ACE extra (for adding extra ace items to players or box)";
+			this.init_ace_checkbox.Text = "Init ACE extra (for adding extra ace items)";
 			this.init_ace_checkbox.UseVisualStyleBackColor = true;
-			// 
-			// init_ace_label2
-			// 
-			this.init_ace_label2.AutoSize = true;
-			this.init_ace_label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.init_ace_label2.Location = new System.Drawing.Point(14, 186);
-			this.init_ace_label2.Name = "init_ace_label2";
-			this.init_ace_label2.Size = new System.Drawing.Size(347, 17);
-			this.init_ace_label2.TabIndex = 29;
-			this.init_ace_label2.Text = "addItemCargoGlobal [\"ACE_bloodIV\", 2]; or something";
 			// 
 			// Form3_Description
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.ClientSize = new System.Drawing.Size(464, 517);
-			this.Controls.Add(this.init_ace_label2);
 			this.Controls.Add(this.init_ace_label);
 			this.Controls.Add(this.init_ace_checkbox);
 			this.Controls.Add(this.description_params_difficulty_checkbox);
@@ -239,6 +227,5 @@
 		private System.Windows.Forms.CheckBox description_params_difficulty_checkbox;
 		private System.Windows.Forms.Label init_ace_label;
 		private System.Windows.Forms.CheckBox init_ace_checkbox;
-		private System.Windows.Forms.Label init_ace_label2;
 	}
 }

--- a/Arma3PhantomMissionEditorLoader/Form3_Description.cs
+++ b/Arma3PhantomMissionEditorLoader/Form3_Description.cs
@@ -118,17 +118,30 @@ namespace Arma3PhantomMissionEditorLoader
 
 		private void writeParametersHPP()
 		{
-			if (description_params_scale_players_checkbox.Checked)
+			if (descriptionParametersIsEnabled())
 			{
 				using (System.IO.StreamWriter sw = new System.IO.StreamWriter(System.IO.Path.Combine(this.missionDirectory, FOLDER_SCRIPTS, PARAMETERS)))
 				{
-					sw.WriteLine("class ScalePlayers");
-					sw.WriteLine("{");
-					sw.WriteLine("	title = \"Low Player Count Scale Mode\";");
-					sw.WriteLine("	values[] = {0, 1};");
-					sw.WriteLine("	texts[] = {\"Disable\", \"Enable\"};");
-					sw.WriteLine("	default = 0;");
-					sw.WriteLine("};");
+					if (description_params_scale_players_checkbox.Checked)
+					{
+						sw.WriteLine("class ScalePlayers");
+						sw.WriteLine("{");
+						sw.WriteLine("	title = \"Low Player Count Scale Mode\";");
+						sw.WriteLine("	values[] = {0, 1};");
+						sw.WriteLine("	texts[] = {\"Disable\", \"Enable\"};");
+						sw.WriteLine("	default = 0;");
+						sw.WriteLine("};");
+					}
+					if (description_params_scale_players_checkbox.Checked)
+					{
+						sw.WriteLine("class FHQ_Difficulty");
+						sw.WriteLine("{");
+						sw.WriteLine("	title = \"Difficulty\";");
+						sw.WriteLine("	values[] = {0, 1, 2};");
+						sw.WriteLine("	texts[] = {\"Easy\", \"Normal\", \"Hard\"};");
+						sw.WriteLine("	default = 1;");
+						sw.WriteLine("};");
+					}
 				}
 			}
 		}
@@ -153,6 +166,11 @@ namespace Arma3PhantomMissionEditorLoader
 			infoTextResult += "]";
 
 			return infoTextResult;
+		}
+
+		private Boolean descriptionParametersIsEnabled()
+		{
+			return description_params_scale_players_checkbox.Checked || description_params_scale_players_checkbox.Checked;
 		}
 	}
 }

--- a/Arma3PhantomMissionEditorLoader/Form3_Description.cs
+++ b/Arma3PhantomMissionEditorLoader/Form3_Description.cs
@@ -58,7 +58,7 @@ namespace Arma3PhantomMissionEditorLoader
 			// Set parameters information once button is click to get checkbox latest state
 			this.parameters = new Dictionary<String, Object>
 			{
-				{"description_params", description_params_checkbox.Checked},
+				{"description_params", description_params_scale_players_checkbox.Checked},
 				{"init_zeus", init_zeus_checkbox.Checked},
 				{"description", new Dictionary<String, Object>
 					{
@@ -67,7 +67,7 @@ namespace Arma3PhantomMissionEditorLoader
 						{"onLoadMission", onLoadMission},
 						{"minPlayers", minPlayers},
 						{"maxPlayers", maxPlayers},
-						{"descriptionParams", description_params_checkbox.Checked},
+						{"descriptionParams", description_params_scale_players_checkbox.Checked},
 						{"descriptionLoadout", description_loadout_checkbox.Checked}
 					}
 				}
@@ -118,7 +118,7 @@ namespace Arma3PhantomMissionEditorLoader
 
 		private void writeParametersHPP()
 		{
-			if (description_params_checkbox.Checked)
+			if (description_params_scale_players_checkbox.Checked)
 			{
 				using (System.IO.StreamWriter sw = new System.IO.StreamWriter(System.IO.Path.Combine(this.missionDirectory, FOLDER_SCRIPTS, PARAMETERS)))
 				{

--- a/Arma3PhantomMissionEditorLoader/Form3_Description.cs
+++ b/Arma3PhantomMissionEditorLoader/Form3_Description.cs
@@ -59,6 +59,7 @@ namespace Arma3PhantomMissionEditorLoader
 			this.parameters = new Dictionary<String, Object>
 			{
 				{"description_params", description_params_scale_players_checkbox.Checked},
+				{"init_ace", init_ace_checkbox.Checked},
 				{"init_zeus", init_zeus_checkbox.Checked},
 				{"description", new Dictionary<String, Object>
 					{

--- a/Arma3PhantomMissionEditorLoader/Form5_Debrief.cs
+++ b/Arma3PhantomMissionEditorLoader/Form5_Debrief.cs
@@ -184,6 +184,16 @@ namespace Arma3PhantomMissionEditorLoader
 					sw.WriteLine("	// TODO");
 					sw.WriteLine("};");
 				}
+				if ((bool)this.parameters["init_ace"])
+				{
+					sw.WriteLine("");
+					sw.WriteLine("// Adds extra ace equipments to player's uniforms or vests.");
+					sw.WriteLine("//	Example 1: ammobox1 addItemCargoGlobal [\"ACE_bloodIV\", 2];");
+					sw.WriteLine("//	Example 2: uniformContainer p1 addMagazineCargoGlobal [\"ACE_M84\", 6];");
+					sw.WriteLine("if (isServer && isClass (configFile >> \"CfgMods\" >> \"ace\")) then {");
+					sw.WriteLine("	// TODO");
+					sw.WriteLine("};");
+				}
 				if ((bool)this.parameters["init_zeus"])
 				{
 					sw.WriteLine("");

--- a/Arma3PhantomMissionEditorLoader/Form5_Debrief.cs
+++ b/Arma3PhantomMissionEditorLoader/Form5_Debrief.cs
@@ -17,9 +17,12 @@ namespace Arma3PhantomMissionEditorLoader
 		private const String DESCRIPTION = "description.ext";
 		private const String INIT = "init.sqf";
 
+		private const String ERROR_NO_DEBRIEFING = "Please add at least one debriefing.";
+
 		private String missionDirectory;
 		private HashSet<String> classNames;
 		private Dictionary<String, Object> parameters;
+		private Boolean hasAtLeastOneDebriefing;
 
 		public Form5_Debrief(String missionDirectory, Dictionary<String, Object> parameters)
 		{
@@ -27,6 +30,7 @@ namespace Arma3PhantomMissionEditorLoader
 			this.missionDirectory = missionDirectory;
 			this.parameters = parameters;
 			classNames = new HashSet<string>();
+			hasAtLeastOneDebriefing = false;
 		}
 
 		private void button_add_Click(object sender, EventArgs e)
@@ -54,6 +58,7 @@ namespace Arma3PhantomMissionEditorLoader
 			// Note: No sanitizing picture Background for now. So either use existing loadscreen.jpg or get the path right.
 			else
 			{
+				hasAtLeastOneDebriefing = true;
 				this.classNames.Add(textbox_classname.Text.Trim());
 
 				using (System.IO.StreamWriter sw = new System.IO.StreamWriter(System.IO.Path.Combine(this.missionDirectory, DEBRIEFING), true))
@@ -84,6 +89,12 @@ namespace Arma3PhantomMissionEditorLoader
 
 		private void button_complete_Click(object sender, EventArgs e)
 		{
+			if (!hasAtLeastOneDebriefing)
+			{
+				MessageBox.Show(ERROR_NO_DEBRIEFING);
+				return;
+			}
+
 			// Write description.ext
 			writeDescriptionExt();
 

--- a/Arma3PhantomMissionEditorLoader/Form6_Briefing.cs
+++ b/Arma3PhantomMissionEditorLoader/Form6_Briefing.cs
@@ -18,14 +18,18 @@ namespace Arma3PhantomMissionEditorLoader
 		private const String BRIEFING = "briefing.sqf";
 		private const String FOLDER_SCRIPTS = "scripts";
 
+		private const String ERROR_NO_BRIEFING = "Please add at least one briefing.";
+
 		private String missionDirectory;
 		private bool firstItemAdded;
+		private Boolean hasAtLeastOneBriefing;
 
 		public Form6_Briefing(String missionDirectory)
 		{
 			InitializeComponent();
 			this.missionDirectory = missionDirectory;
 			firstItemAdded = false;
+			hasAtLeastOneBriefing = false;
 
 			// Setup color dialog
 			this.colorDiaglog = new ColorDialog();
@@ -55,12 +59,19 @@ namespace Arma3PhantomMissionEditorLoader
 					sw.WriteLine("		[\"" + textbox_title.Text.Replace("\"", "\"\"") + "\",");
 					sw.Write("			\"" + textbox_description.Text.Replace("\"", "\"\"").Replace(Environment.NewLine, "<br/>").Replace("'\"\" + _htmlcolor + \"\"'", "'\" + _htmlcolor + \"'") + "\"]"); 
 					firstItemAdded = true;
+					hasAtLeastOneBriefing = true;
 				}
 			}
 		}
 
 		private void button_complete_Click(object sender, EventArgs e)
 		{
+			if (!hasAtLeastOneBriefing)
+			{
+				MessageBox.Show(ERROR_NO_BRIEFING);
+				return;
+			}
+
 			using (System.IO.StreamWriter sw = new System.IO.StreamWriter(System.IO.Path.Combine(this.missionDirectory, FOLDER_SCRIPTS, BRIEFING), true))
 			{
 				sw.WriteLine("");

--- a/Arma3PhantomMissionEditorLoader/Form7_Briefing_Task.cs
+++ b/Arma3PhantomMissionEditorLoader/Form7_Briefing_Task.cs
@@ -18,10 +18,13 @@ namespace Arma3PhantomMissionEditorLoader
 		private const String BRIEFING = "briefing.sqf";
 		private const String FOLDER_SCRIPTS = "scripts";
 
+		private const String ERROR_NO_TASK = "Please add at least one task.";
+
 		private String missionDirectory;
 		private bool firstItemAdded;
 		private bool firstAssignedTaskStateFound;
 		private HashSet<string> taskNames;
+		private Boolean hasAtLeastOneTask;
 
 		public Form7_Briefing_Task(String missionDirectory)
 		{
@@ -30,6 +33,7 @@ namespace Arma3PhantomMissionEditorLoader
 			firstItemAdded = false;
 			firstAssignedTaskStateFound = false;
 			taskNames = new HashSet<string>();
+			hasAtLeastOneTask = false;
 
 			// Setup color dialog
 			this.colorDiaglog = new ColorDialog();
@@ -95,12 +99,19 @@ namespace Arma3PhantomMissionEditorLoader
 
 					taskNames.Add(textbox_taskname.Text.Trim().ToLower());
 					firstItemAdded = true;
+					hasAtLeastOneTask = true;
 				}
 			}
 		}
 
 		private void button_complete_Click(object sender, EventArgs e)
 		{
+			if (!hasAtLeastOneTask)
+			{
+				MessageBox.Show(ERROR_NO_TASK);
+				return;
+			}
+
 			using (System.IO.StreamWriter sw = new System.IO.StreamWriter(System.IO.Path.Combine(this.missionDirectory, FOLDER_SCRIPTS, BRIEFING), true))
 			{
 				sw.WriteLine("");

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 <a href="https://github.com/bennpham/Arma3PhantomMissionEditorLoader/releases/tag/v1.2.0"><img src="https://img.shields.io/badge/Version-1.2.0-blue.svg" alt="Download Mission Loader" /></a>
 </p>
 
-An application to modify my Arma 3 <b>mission.sqm</b> file to set the settings that I need in one go and generate some basic scripts to help me focus on unit placement and making the missions rather than copying over the same files for my template and modifying them separately instead. 
+An application to modify my Arma 3 <b>mission.sqm</b> file to set the settings that I need in one go and generate some basic scripts to help me focus on unit placement and making the missions rather than copying over the same files for my template and modifying them separately instead.
 
 ## Usage
 ### Getting Started
 * Create a new mission in Arma 3 mission
 * Unbinarize your mission and save it
-* Make sure only the <b>mission.sqm</b> is inside the folder 
+* Make sure only the <b>mission.sqm</b> is inside the folder
 * Run the Mission Editor Loader and select the path to your new mission folder that contains just the unbinarize <b>mission.sqm</b> file and click new
 ### Editing Mission.sqm
 * Fill out all of the information on the first form that appears
-* This form should modify some information on your <b>mission.sqm</b> and <b>description.ext</b> including author information, mission overview text, Multiplayer settings, mission summary, weather settings, and etc. 
+* This form should modify some information on your <b>mission.sqm</b> and <b>description.ext</b> including author information, mission overview text, Multiplayer settings, mission summary, weather settings, and etc.
 * By default, this application is <b>SIDE</b> respawn only and is meant for no respawn/revive type of coop gameplay.
 * Click okay when you are done
 ### Editing Description.ext & Infotext Script
@@ -22,16 +22,28 @@ An application to modify my Arma 3 <b>mission.sqm</b> file to set the settings t
 	* You'll need to do that manually through the <b>init.sqf</b> or <b>triggers</b>
 * Check off <b>Description Params (FHQ Difficulty)</b> if you want to delete units base on MP difficulty settings.
 	* You can do that manually or use [FHQ Eden Tool](http://ciahome.net/forum/showthread.php?tid=3935) which is highly recommended for this step.
-* Check out <b>Description Loadout</b> if you want to setup briefing loadouts. 
+* Check out <b>Description Loadout</b> if you want to setup briefing loadouts.
 	* This is for Singleplayer only and you'll have to handle those manually in <b>scripts/briefing_loadout.hpp</b>.
 * Check off <b>Init ACE Extra</b> if you want to add extra equipment to units, vehicles, or ammoboxes if the server or player has ACE loaded.
 	* You'll need to do that manually in the ACE condition block in <b>init.sqf</b>.
 	* You'll also want to refer to [ACE 3 Mod Classname Wiki](https://ace3mod.com/wiki/class-names.html).
-* Check off <b>Init Zeus</b> if you want to have all units placed in the editor is controllable by zeus players. 
+* Check off <b>Init Zeus</b> if you want to have all units placed in the editor is controllable by zeus players.
 	* You can place 3 zeus slots named `zeus_mod1`, `zeus_mod2`, `zeus_mod3` yourself or you can place them in via my mission composition.
 * The default info text will display the date and time, followed by the text you inputted in the text box, then your name (as the author)
 ### Scripts to Enable
-* By default, FHQ TaskTracker will always be enabled. You can choose to enable additional scripts here.
+* By default, FHQ TaskTracker will always be enabled.
+* You can choose to enable additional scripts here.
+* If you need help on additional setup for any of the scripts or description parameters that requires it, refer to [the setup guide](https://github.com/bennpham/Arma3PhantomMissionEditorLoader/blob/master/SETUP.md).
+* The following parameters will require additional setup:
+	* Description Params (Player Count Scale)
+	* Description Params (FHQ Difficulty)
+	* Description Loadout (Singleplayer Only)
+	* Init ACE Extra
+	* FHQ Detected By
+	* FHQ Force Tracker
+	* FHQ Marker Patrol
+	* FHQ Safe Add Loadout
+
 ### Debriefing Editor
 * This setups the <b>debriefing</b> section of <b>description.ext</b> and is located in <b>debriefing.hpp</b>
 * You can setup the default class name (they must be unique) for win or lose condition or any other custom conditions you have for how your mission can end
@@ -44,7 +56,7 @@ An application to modify my Arma 3 <b>mission.sqm</b> file to set the settings t
 * You can also use <b>Text</b>, <b>Color</b>, or <b>Marker</b> to customize task description marker and text color
 * Only 1 task state can be assigned
 ### Final Notes
-* When everything is good and done, feel free to delete your <b>mission.sqm.old</b> and re-binarize your <b>mission.sqm</b>. 
+* When everything is good and done, feel free to delete your <b>mission.sqm.old</b> and re-binarize your <b>mission.sqm</b>.
 
 ## Notes
 * If you break your <b>mission.sqm</b> in any way, you can delete it and rename the <b>mission.sqm.old</b> (which is the backup of your old <b>mission.sqm</b> before editing)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arma 3 Phantom Mission Editor Loader
 
 <p align="center">
-<a href="https://github.com/bennpham/Arma3PhantomMissionEditorLoader/releases/tag/v1.1.1"><img src="https://img.shields.io/badge/Version-1.1.1-blue.svg" alt="Download Mission Loader" /></a>
+<a href="https://github.com/bennpham/Arma3PhantomMissionEditorLoader/releases/tag/v1.2.0"><img src="https://img.shields.io/badge/Version-1.2.0-blue.svg" alt="Download Mission Loader" /></a>
 </p>
 
 An application to modify my Arma 3 <b>mission.sqm</b> file to set the settings that I need in one go and generate some basic scripts to help me focus on unit placement and making the missions rather than copying over the same files for my template and modifying them separately instead. 
@@ -18,9 +18,17 @@ An application to modify my Arma 3 <b>mission.sqm</b> file to set the settings t
 * By default, this application is <b>SIDE</b> respawn only and is meant for no respawn/revive type of coop gameplay.
 * Click okay when you are done
 ### Editing Description.ext & Infotext Script
-* Check off <b>Description Params</b> if you want in game parameters to scale units or other settings for the players in game (you'll need to do that manually through the <b>init.sqf</b> or <b>triggers</b>)
-* Check out <b>Description Loadout</b> if you want to setup briefing loadouts. This is for Singleplayer only and you'll have to handle those manually in <b>scripts/briefing_loadout.hpp</b>
-* Check off <b>Init Zeus</b> if you want to have all units placed in the editor is controllable by zeus players. You can place 3 zeus slots named zeus_mod1, zeus_mod2, zeus_mod3 yourself or you can place them in via my mission composition
+* Check off <b>Description Params (Player Count Scale)</b> if you want in game parameters to scale units or other settings for the players in game.
+	* You'll need to do that manually through the <b>init.sqf</b> or <b>triggers</b>
+* Check off <b>Description Params (FHQ Difficulty)</b> if you want to delete units base on MP difficulty settings.
+	* You can do that manually or use [FHQ Eden Tool](http://ciahome.net/forum/showthread.php?tid=3935) which is highly recommended for this step.
+* Check out <b>Description Loadout</b> if you want to setup briefing loadouts. 
+	* This is for Singleplayer only and you'll have to handle those manually in <b>scripts/briefing_loadout.hpp</b>.
+* Check off <b>Init ACE Extra</b> if you want to add extra equipments to units, vehicles, or ammoboxes if the server or player has ACE loaded.
+	* You'll need to that manually in the ACE condition block in <b>init.sqf</b>.
+	* You'll also want to refer to [ACE 3 Mod Classname Wiki](https://ace3mod.com/wiki/class-names.html).
+* Check off <b>Init Zeus</b> if you want to have all units placed in the editor is controllable by zeus players. 
+	* You can place 3 zeus slots named `zeus_mod1`, `zeus_mod2`, `zeus_mod3` yourself or you can place them in via my mission composition.
 * The default info text will display the date and time, followed by the text you inputted in the text box, then your name (as the author)
 ### Scripts to Enable
 * By default, FHQ TaskTracker will always be enabled. You can choose to enable additional scripts here.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ An application to modify my Arma 3 <b>mission.sqm</b> file to set the settings t
 	* You can do that manually or use [FHQ Eden Tool](http://ciahome.net/forum/showthread.php?tid=3935) which is highly recommended for this step.
 * Check out <b>Description Loadout</b> if you want to setup briefing loadouts. 
 	* This is for Singleplayer only and you'll have to handle those manually in <b>scripts/briefing_loadout.hpp</b>.
-* Check off <b>Init ACE Extra</b> if you want to add extra equipments to units, vehicles, or ammoboxes if the server or player has ACE loaded.
-	* You'll need to that manually in the ACE condition block in <b>init.sqf</b>.
+* Check off <b>Init ACE Extra</b> if you want to add extra equipment to units, vehicles, or ammoboxes if the server or player has ACE loaded.
+	* You'll need to do that manually in the ACE condition block in <b>init.sqf</b>.
 	* You'll also want to refer to [ACE 3 Mod Classname Wiki](https://ace3mod.com/wiki/class-names.html).
 * Check off <b>Init Zeus</b> if you want to have all units placed in the editor is controllable by zeus players. 
 	* You can place 3 zeus slots named `zeus_mod1`, `zeus_mod2`, `zeus_mod3` yourself or you can place them in via my mission composition.

--- a/SETUP.md
+++ b/SETUP.md
@@ -61,7 +61,7 @@ This is useful for attempting to scale units back base on player counts if you e
 
 ```
 {
-	if (_x getVariable ["FHQ_TagA", true]) then {
+	if (_x getVariable ["FHQ_TagA", false]) then {
 		deleteVehicle _x;
 	};
 } foreach allUnits;

--- a/SETUP.md
+++ b/SETUP.md
@@ -14,7 +14,7 @@ In **init.sqf**, there should be the following code block:
 ```
 // Adds extra ace equipments to player's uniforms or vests.
 //	Example 1: ammobox1 addItemCargoGlobal ["ACE_bloodIV", 2];
-//	Example 2: uniformContainer p1 addMagazineCargoGlobal [\"ACE_M84\", 6];
+//	Example 2: uniformContainer p1 addMagazineCargoGlobal ["ACE_M84", 6];
 if (isServer && isClass (configFile >> "CfgMods" >> "ace")) then {
     // TODO
 };

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,238 @@
+# Additional Script Setup Guide Plus Tips
+
+The purpose of this guide is to help you with any additional setups for additional scripts or description.ext settings you enabled as well as provide a few other helpful editing tips.
+
+## Additional Setup
+
+
+### Handling extra ACE loadouts
+
+Refer to https://ace3mod.com/wiki/class-names.html for list of ACE classnames.
+
+In **init.sqf**, there should be the following code block:
+
+```
+// Adds extra ace equipments to player's uniforms or vests.
+//	Example 1: ammobox1 addItemCargoGlobal ["ACE_bloodIV", 2];
+//	Example 2: uniformContainer p1 addMagazineCargoGlobal [\"ACE_M84\", 6];
+if (isServer && isClass (configFile >> "CfgMods" >> "ace")) then {
+    // TODO
+};
+```
+
+You'll need to replace `TODO` with something like the following:
+
+```
+ammobox addItemCargoGlobal ["ACE_bloodIV", 2];
+
+uniformContainer p1 addMagazineCargoGlobal ["ACE_M84", 6];
+vestContainer p1 addMagazineCargoGlobal ["ACE_M84", 6];
+unitBackPack p1 addItemCargoGlobal ["ACE_bloodIV", 2];
+```
+
+### FHQ Task Tracker Settings
+
+To set a task as success, cancel, or fail:
+
+```
+["task1", "succeeded"] call FHQ_fnc_ttSetTaskState;
+["task1", "cancelled"] call FHQ_fnc_ttSetTaskState;
+["task1", "failed"] call FHQ_fnc_ttSetTaskState;
+```
+
+Use for conditions or if statements to check that tasks are successful:
+
+```
+["task1", "task2", "task3"] call FHQ_fnc_ttAreTasksSuccessful
+["task1"] call FHQ_fnc_ttIsTaskSuccessful
+```
+
+Use to check that the task has fail or was cancelled:
+
+```
+["task1"] call FHQ_fnc_ttIsTaskCompleted &&
+!(["task1"] call FHQ_fnc_ttIsTaskSuccessful)
+```
+
+
+### Delete all units with FHQ_Tag when using FHQ Eden Plugin
+
+This is useful for attempting to scale units back base on player counts if you enabled **Description Params (Player Count Scale)**.
+
+```
+{
+	if (_x getVariable ["FHQ_TagA", true]) then {
+		deleteVehicle _x;
+	};
+} foreach allUnits;
+```
+
+
+### FHQ Detect
+
+* Create a repeatable trigger with OPFOR present (if enemy forces are OPFOR)
+	* use BLUFOR or IND if enemy forces are on that side instead
+* Parameter 1: Group of units that'll trigger detection if spotted
+* Parameter 2: The trigger you want to check
+
+```
+[playableUnits, thisList] call FHQ_fnc_detectedBy
+
+[(if (isMultiplayer) then {playableUnits} else {switchableUnits}), thisList] call FHQ_fnc_detectedBy
+
+[[unit1,unit2,unit3,unit4]], thisList] call FHQ_fnc_detectedBy
+```
+
+
+### FHQ Force Tracker
+
+Adds map markers to track your units on the map. In your `init.sqf` after `call compile preProcessFileLineNumbers "scripts\briefing.sqf";`, add the following lines
+
+```
+[grp_alpha, "inf", "Alpha"] call FHQ_fnc_forceTrackAdd;
+[grp_bravo, "inf", "Bravo"] call FHQ_fnc_forceTrackAdd;
+[grp_eagle, "air", "Eagle"] call FHQ_fnc_forceTrackAdd;
+
+call FHQ_fnc_forceTrackStart;
+```
+
+* Parameter 1: Group name
+* Parameter 2: Marker type (refer to https://community.bistudio.com/wiki/cfgMarkers minus side prefix <default to `inf`>)
+* Parameter 3: Name/Callsign (default to group name)
+* Parameter 4: Icon Scale (does nothing)
+* Parameter 5: Color (default to side color)
+
+* Call `[grp] call FHQ_fnc_forceTrackRemove;` to remove group from force tracking and delete icon.
+* Call `[2] call FHQ_fnc_forceTrackSetDelay;` to delay icon update by 2 seconds if performance is impacted
+	* You can use `0.1` for smoothest display if performance isn't a problem
+	* Default is `0.3`
+
+
+### FHQ Marker Patrol
+
+* Create an area marker called `area0` then put the following commands in the group leader's init.
+* You might want to make sure that the group leader has a name.
+
+```
+[this, "area0"] call FHQ_fnc_markerPatrol;
+[this, "area0", 6, false, false, true] call FHQ_fnc_markerPatrol;
+```
+
+* Parameter 1: group or leader of group
+* Parameter 2: name of the marker (default: name of group leader)
+* Parameter 3: number of waypoints for group (default: 6)
+* Parameter 4: generate new waypoint at end of patrol (default: false)
+* Parameter 5: prefer waypoints near road (default: false)
+* Parameter 6: deletes all previous waypoints (default: true)
+
+
+### FHQ Loadout
+
+Put this in the unit init or spawn script and replace `this` with unit name
+
+```
+[this, "scripts\loadout\gun.sqf"] call FHQ_fnc_safeAddLoadout;
+```
+
+I recommend that you generate the loadout via [FHQ Debug Console](http://ciahome.net/forum/showthread.php?tid=3723).
+
+
+
+## Editing Tips
+
+### Display to all players
+
+This will come in handy for something like cutText and hints where you want all players to see the message on dedicated servers.
+
+```
+["Text to display in the hint"] remoteExec ["hint"];
+[["Hello World!", "PLAIN DOWN"]] remoteExec ["cutText"];
+```
+
+If you don't use `remoteExec`, some players will see the message on dedicated servers while others will not.
+
+### Calling External Scripts
+
+In your triggers `on activation` box, add the following:
+
+```
+call compile preprocessFileLineNumbers "scripts\spawn\enemy_spawn.sqf";
+```
+
+Make sure if your script should only need to run server side, you wrap your code with a `if (isServer) then {};` block to only run it once, otherwise the script will run multiple times by the number of players on the server for each client.
+
+Example spawn script:
+
+```
+if (isServer) then {
+	_enemyCar = "CUP_O_LR_MG_TKM" createVehicle [(getMarkerPos "spawn") select 0,(getMarkerPos "spawn") select 1,0];
+	_car setDir 180;
+
+	enemyGrp = createCenter east;
+	enemyGrp = createGroup east;
+	_leader = enemyGrp createUnit ["CUP_O_TK_INS_Soldier", [(getMarkerPos "spawn") select 0,(getMarkerPos "spawn") select 1,0], [], 3, "FORM"];
+	_unit1 = enemyGrp createUnit ["CUP_O_TK_INS_Soldier", [(getMarkerPos "spawn") select 0,(getMarkerPos "spawn") select 1,0], [], 3, "FORM"];
+
+	[_leader, "scripts\loadout\rifle_ak47.sqf"] call FHQ_fnc_safeAddLoadout;
+	[_unit1, "scripts\loadout\rifle_ak47.sqf"] call FHQ_fnc_safeAddLoadout;
+
+	_leader setskill 0.65;
+	_unit1 setskill 0.33;
+	_leader = leader enemyGrp;
+
+	_leader moveInDriver _enemyCar;
+	_unit1 moveInGunner _enemyCar;
+
+	wp1 = enemyGrp addWaypoint [getMarkerPos "attack_path", 0];
+	wp1 setWaypointType "MOVE";
+	wp1 setWaypointStatements ["true", ""];
+
+	wp2 = enemyGrp addWaypoint [getMarkerPos "start", 0, 50];
+	wp2 setWaypointType "SAD";
+	wp2 setWaypointStatements ["true", ""];
+
+	wp3 = enemyGrp addWaypoint [getMarkerPos "start", 0];
+	wp3 setWaypointType "CYCLE";
+	wp3 setWaypointStatements ["true", ""];
+};
+```
+
+Example ammobox script:
+
+```
+if (isServer) then {
+
+	clearmagazinecargoglobal _this;
+	clearweaponcargoglobal _this;
+	clearItemCargoglobal _this;
+	clearBackpackCargoGlobal _this;
+
+	// Weapons
+	_this addWeaponCargoGlobal ["CUP_arifle_AKM", 2];
+
+	// Ammo
+	_this addMagazineCargo ["CUP_30Rnd_762x39_AK47_M", 50];
+
+	// Grenades & Satchels
+	_this addMagazineCargo ["CUP_PipeBomb_M", 10];
+	_this addMagazineCargo ["CUP_MineE_M", 10];
+
+	// Item
+	_this addItemCargoGlobal ["FirstAidKit", 10];
+	_this addItemCargoGlobal ["MediKit", 5];
+
+	// Backpack
+	_this addBackpackCargoGlobal ["CUP_B_RUS_Backpack", 3];
+	_this addBackpackCargoGlobal ["CUP_B_RPGPack_Khaki", 2];
+
+	// Add ACE equipments if ACE is loaded
+	if (isClass (configFile >> "CfgMods" >> "ace")) then {
+		_this addItemCargoGlobal ["ACE_Flashlight_MX991", 5];
+		_this addItemCargoGlobal ["ACE_EarPlugs", 5];
+		_this addItemCargoGlobal ["ACE_MapTools", 5];
+		_this addItemCargoGlobal ["ACE_Clacker", 5];
+		_this addItemCargoGlobal ["ACE_RangeCard", 1];
+		_this addItemCargoGlobal ["ACE_SpottingScope", 1];
+	};
+};
+```


### PR DESCRIPTION
Also resolves https://github.com/bennpham/Arma3PhantomMissionEditorLoader/issues/6

* Adds extra options in Description section
  * Description Params (FHQ Difficulty)
  * Init ACE Extra (for adding extra ace items)
* Trimmed off day on Infotext time of day
  * This was bleeding off the screen when the actual infotext was running ingame
* Readme and a new **Setup.md** file was created to give users more information on the various options
* Prevents users from skipping the debriefing, briefing, and tasks if they left it blank to avoid script errors ingame